### PR TITLE
Remove cargo warning at compile time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ allfeat_contracts_lang = { version = "0.1.0", path = "lang", default-features = 
 openbrush = { git = "https://github.com/Brushfam/openbrush-contracts", branch = "develop", default-features = false, features = ["psp34"] }
 
 [lib]
-name = "allfeat_contracts"
 path = "src/lib.rs"
 crate-type = [
     "rlib",

--- a/examples/aft22/Cargo.toml
+++ b/examples/aft22/Cargo.toml
@@ -19,9 +19,7 @@ ink_e2e = "4.2.1"
 test_helpers = { git = "https://github.com/Brushfam/openbrush-contracts", branch = "develop", default-features = false }
 
 [lib]
-name = "my_aft22"
 path = "src/lib.rs"
-
 
 [features]
 default = ["std"]

--- a/examples/aft22_extensions/burnable/Cargo.toml
+++ b/examples/aft22_extensions/burnable/Cargo.toml
@@ -19,9 +19,7 @@ ink_e2e = "4.2.1"
 test_helpers = { git = "https://github.com/Brushfam/openbrush-contracts", branch = "develop", default-features = false }
 
 [lib]
-name = "my_aft22_burnable"
 path = "src/lib.rs"
-
 
 [features]
 default = ["std"]

--- a/examples/aft22_extensions/capped/Cargo.toml
+++ b/examples/aft22_extensions/capped/Cargo.toml
@@ -19,9 +19,7 @@ ink_e2e = "4.2.1"
 test_helpers = { git = "https://github.com/Brushfam/openbrush-contracts", branch = "develop", default-features = false }
 
 [lib]
-name = "my_aft22_capped"
 path = "src/lib.rs"
-
 
 [features]
 default = ["std"]

--- a/examples/aft22_extensions/flashmint/Cargo.toml
+++ b/examples/aft22_extensions/flashmint/Cargo.toml
@@ -15,9 +15,7 @@ allfeat-contracts = { path = "../../..", default-features = false, features = ["
 openbrush = { git = "https://github.com/Brushfam/openbrush-contracts", branch = "develop", default-features = false }
 
 [lib]
-name = "my_aft22_flashmint"
 path = "src/lib.rs"
-
 
 [features]
 default = ["std"]

--- a/examples/aft22_extensions/metadata/Cargo.toml
+++ b/examples/aft22_extensions/metadata/Cargo.toml
@@ -19,9 +19,7 @@ ink_e2e = "4.2.1"
 test_helpers = { git = "https://github.com/Brushfam/openbrush-contracts", branch = "develop", default-features = false }
 
 [lib]
-name = "my_aft22_metadata"
 path = "src/lib.rs"
-
 
 [features]
 default = ["std"]

--- a/examples/aft22_extensions/mintable/Cargo.toml
+++ b/examples/aft22_extensions/mintable/Cargo.toml
@@ -19,9 +19,7 @@ ink_e2e = "4.2.1"
 test_helpers = { git = "https://github.com/Brushfam/openbrush-contracts", branch = "develop", default-features = false }
 
 [lib]
-name = "my_aft22_mintable"
 path = "src/lib.rs"
-
 
 [features]
 default = ["std"]

--- a/examples/aft22_extensions/wrapper/Cargo.toml
+++ b/examples/aft22_extensions/wrapper/Cargo.toml
@@ -15,9 +15,7 @@ allfeat-contracts = { path = "../../..", default-features = false, features = ["
 openbrush = { git = "https://github.com/Brushfam/openbrush-contracts", branch = "develop", default-features = false }
 
 [lib]
-name = "my_aft22_wrapper"
 path = "src/lib.rs"
-
 
 [features]
 default = ["std"]

--- a/examples/aft34/Cargo.toml
+++ b/examples/aft34/Cargo.toml
@@ -19,9 +19,7 @@ ink_e2e = "4.2.1"
 test_helpers = { git = "https://github.com/Brushfam/openbrush-contracts", branch = "develop", default-features = false }
 
 [lib]
-name = "my_aft34"
 path = "src/lib.rs"
-
 
 [features]
 default = ["std"]

--- a/examples/aft34_extensions/burnable/Cargo.toml
+++ b/examples/aft34_extensions/burnable/Cargo.toml
@@ -19,9 +19,7 @@ ink_e2e = "4.2.1"
 test_helpers = { git = "https://github.com/Brushfam/openbrush-contracts", branch = "develop", default-features = false }
 
 [lib]
-name = "my_aft34_burnable"
 path = "src/lib.rs"
-
 
 [features]
 default = ["std"]

--- a/examples/aft34_extensions/enumerable/Cargo.toml
+++ b/examples/aft34_extensions/enumerable/Cargo.toml
@@ -19,9 +19,7 @@ ink_e2e = "4.2.1"
 test_helpers = { git = "https://github.com/Brushfam/openbrush-contracts", branch = "develop", default-features = false }
 
 [lib]
-name = "my_aft34_enumerable"
 path = "src/lib.rs"
-
 
 [features]
 default = ["std"]

--- a/examples/aft34_extensions/metadata/Cargo.toml
+++ b/examples/aft34_extensions/metadata/Cargo.toml
@@ -19,9 +19,7 @@ ink_e2e = "4.2.1"
 test_helpers = { git = "https://github.com/Brushfam/openbrush-contracts", branch = "develop", default-features = false }
 
 [lib]
-name = "my_aft34_metadata"
 path = "src/lib.rs"
-
 
 [features]
 default = ["std"]

--- a/examples/aft34_extensions/mintable/Cargo.toml
+++ b/examples/aft34_extensions/mintable/Cargo.toml
@@ -19,9 +19,7 @@ ink_e2e = "4.2.1"
 test_helpers = { git = "https://github.com/Brushfam/openbrush-contracts", branch = "develop", default-features = false }
 
 [lib]
-name = "my_aft34_mintable"
 path = "src/lib.rs"
-
 
 [features]
 default = ["std"]

--- a/examples/aft37/Cargo.toml
+++ b/examples/aft37/Cargo.toml
@@ -19,9 +19,7 @@ ink_e2e = "4.2.1"
 test_helpers = { git = "https://github.com/Brushfam/openbrush-contracts", branch = "develop", default-features = false }
 
 [lib]
-name = "my_aft37"
 path = "src/lib.rs"
-
 
 [features]
 default = ["std"]

--- a/examples/aft37_extensions/batch/Cargo.toml
+++ b/examples/aft37_extensions/batch/Cargo.toml
@@ -19,9 +19,7 @@ ink_e2e = "4.2.1"
 test_helpers = { git = "https://github.com/Brushfam/openbrush-contracts", branch = "develop", default-features = false }
 
 [lib]
-name = "my_aft37_batch"
 path = "src/lib.rs"
-
 
 [features]
 default = ["std"]

--- a/examples/aft37_extensions/burnable/Cargo.toml
+++ b/examples/aft37_extensions/burnable/Cargo.toml
@@ -19,9 +19,7 @@ ink_e2e = "4.2.1"
 test_helpers = { git = "https://github.com/Brushfam/openbrush-contracts", branch = "develop", default-features = false }
 
 [lib]
-name = "my_aft37_burnable"
 path = "src/lib.rs"
-
 
 [features]
 default = ["std"]

--- a/examples/aft37_extensions/enumerable/Cargo.toml
+++ b/examples/aft37_extensions/enumerable/Cargo.toml
@@ -19,7 +19,6 @@ ink_e2e = "4.2.1"
 test_helpers = { git = "https://github.com/Brushfam/openbrush-contracts", branch = "develop", default-features = false }
 
 [lib]
-name = "my_aft37_enumerable"
 path = "src/lib.rs"
 
 

--- a/examples/aft37_extensions/metadata/Cargo.toml
+++ b/examples/aft37_extensions/metadata/Cargo.toml
@@ -19,7 +19,6 @@ ink_e2e = "4.2.1"
 test_helpers = { git = "https://github.com/Brushfam/openbrush-contracts", branch = "develop", default-features = false }
 
 [lib]
-name = "my_aft37_metadata"
 path = "src/lib.rs"
 
 

--- a/examples/aft37_extensions/mintable/Cargo.toml
+++ b/examples/aft37_extensions/mintable/Cargo.toml
@@ -19,9 +19,7 @@ ink_e2e = "4.2.1"
 test_helpers = { git = "https://github.com/Brushfam/openbrush-contracts", branch = "develop", default-features = false }
 
 [lib]
-name = "my_aft37_mintable"
 path = "src/lib.rs"
-
 
 [features]
 default = ["std"]

--- a/examples/ownable/Cargo.toml
+++ b/examples/ownable/Cargo.toml
@@ -19,9 +19,7 @@ ink_e2e = "4.2.1"
 test_helpers = { git = "https://github.com/Brushfam/openbrush-contracts", branch = "develop", default-features = false }
 
 [lib]
-name = "my_ownable"
 path = "src/lib.rs"
-
 
 [features]
 default = ["std"]


### PR DESCRIPTION
This pull request aims to remove the following `Cargo` compilation warning:

```bash
warning: the `name` field in the `[lib]` section of the `Cargo.toml`, is no longer used for the name of generated contract artifacts. The package name is used instead. Remove the `[lib] name` to stop this warning.
```