### PR TITLE
Change ZeroAddress errors on IsNotSet errors

### DIFF
--- a/src/traits/errors/aft22.rs
+++ b/src/traits/errors/aft22.rs
@@ -50,7 +50,9 @@ impl From<OwnableError> for AFT22Error {
             OwnableError::CallerIsNotOwner => {
                 AFT22Error::Custom(String::from("O::CallerIsNotOwner"))
             }
-            OwnableError::NewOwnerIsZero => AFT22Error::Custom(String::from("O::NewOwnerIsZero")),
+            OwnableError::NewOwnerIsNotSet => {
+                AFT22Error::Custom(String::from("O::NewOwnerIsNotSet"))
+            }
         }
     }
 }

--- a/src/traits/errors/aft34.rs
+++ b/src/traits/errors/aft34.rs
@@ -49,7 +49,9 @@ impl From<OwnableError> for AFT34Error {
             OwnableError::CallerIsNotOwner => {
                 AFT34Error::Custom(String::from("O::CallerIsNotOwner"))
             }
-            OwnableError::NewOwnerIsZero => AFT34Error::Custom(String::from("O::NewOwnerIsZero")),
+            OwnableError::NewOwnerIsNotSet => {
+                AFT34Error::Custom(String::from("O::NewOwnerIsNotSet"))
+            }
         }
     }
 }

--- a/src/traits/errors/aft37.rs
+++ b/src/traits/errors/aft37.rs
@@ -50,7 +50,9 @@ impl From<OwnableError> for AFT37Error {
             OwnableError::CallerIsNotOwner => {
                 AFT37Error::Custom(String::from("O::CallerIsNotOwner"))
             }
-            OwnableError::NewOwnerIsZero => AFT37Error::Custom(String::from("O::NewOwnerIsZero")),
+            OwnableError::NewOwnerIsNotSet => {
+                AFT37Error::Custom(String::from("O::NewOwnerIsNotSet"))
+            }
         }
     }
 }


### PR DESCRIPTION
This PR is meant to fix a build error due to a change inside openbrush-contracts.

They renamed `OwnableError::NewOwnerIsZero` to `OwnableError::NewOwnerIsNotSet`